### PR TITLE
parser command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,8 @@
 # Isbn
 
-**TODO: Add description**
+Command line application which take an isbn and returns the book's details
+link to the isbn.
 
-## Installation
+## Example
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `isbn` to your list of dependencies in `mix.exs`:
-
-```elixir
-def deps do
-  [
-    {:isbn, "~> 0.1.0"}
-  ]
-end
-```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/isbn](https://hexdocs.pm/isbn).
-
+`isbn --isbn 9782501053501`

--- a/lib/isbn/cli.ex
+++ b/lib/isbn/cli.ex
@@ -15,6 +15,7 @@ defmodule ISBN.CLI do
     try do
       isbn
       |> String.to_integer()
+      |> Integer.digits()
       |> validate_isbn()
     rescue
       _ -> :help
@@ -25,15 +26,9 @@ defmodule ISBN.CLI do
 
   # Check isbn length is 10 or 13
   # returns isbn or :help if not valid
-  def validate_isbn(isbn) do
-    digits = Integer.digits(isbn)
+  def validate_isbn(isbn) when not (length(isbn) == 10 or length(isbn) == 13), do: :help
 
-    if length(digits) == 10 or length(digits) == 13 do
-      isbn
-    else
-      :help
-    end
-  end
+  def validate_isbn(isbn), do: Integer.undigits(isbn)
 
   def process(:help) do
     IO.puts("""

--- a/lib/isbn/cli.ex
+++ b/lib/isbn/cli.ex
@@ -1,0 +1,49 @@
+defmodule ISBN.CLI do
+  def main(argv) do
+    parse_args(argv)
+  end
+
+  def parse_args(argv) do
+    argv
+    |> OptionParser.parse(switches: [help: :boolean], aliases: [h: :help])
+    |> elem(1)
+    |> args_to_internal_representation()
+    |> process()
+  end
+
+  def args_to_internal_representation([isbn]) do
+    try do
+      isbn
+      |> String.to_integer()
+      |> validate_isbn()
+    rescue
+      _ -> :help
+    end
+  end
+
+  def args_to_internal_representation(_), do: :help
+
+  # Check isbn length is 10 or 13
+  # returns isbn or :help if not valid
+  def validate_isbn(isbn) do
+    digits = Integer.digits(isbn)
+
+    if length(digits) == 10 or length(digits) == 13 do
+      isbn
+    else
+      :help
+    end
+  end
+
+  def process(:help) do
+    IO.puts("""
+    usage: isbn <isbn>
+    """)
+
+    System.halt(0)
+  end
+
+  def process(isbn) do
+    IO.puts("fetch isbn title")
+  end
+end

--- a/lib/isbn/cli.ex
+++ b/lib/isbn/cli.ex
@@ -1,38 +1,52 @@
 defmodule ISBN.CLI do
-  def main(argv) do
-    parse_args(argv)
-  end
+  @moduledoc """
+  Parse command line arguments.
+  """
 
-  def parse_args(argv) do
+  @doc """
+  Process isbn argument
+  """
+  def main(argv) do
     argv
-    |> OptionParser.parse(switches: [help: :boolean], aliases: [h: :help])
-    |> elem(1)
-    |> args_to_internal_representation()
+    |> parse_args()
     |> process()
   end
 
-  def args_to_internal_representation([isbn]) do
-    try do
+  @doc """
+  Returs :help or isbn
+  """
+  def parse_args(argv) do
+    argv
+    |> OptionParser.parse(
+      switches: [help: :boolean, isbn: :integer],
+      aliases: [h: :help, i: :isbn]
+    )
+    |> elem(0)
+    |> args_to_isbn()
+    |> validate_isbn()
+  end
+
+  defp args_to_isbn(isbn: isbn), do: isbn
+  defp args_to_isbn(_), do: nil
+
+  def valid_isbn?(isbn) when is_integer(isbn) do
+    digits = Integer.digits(isbn)
+    length(digits) == 10 or length(digits) == 13
+  end
+
+  def valid_isbn?(_), do: false
+
+  defp validate_isbn(isbn) do
+    if valid_isbn?(isbn) do
       isbn
-      |> String.to_integer()
-      |> Integer.digits()
-      |> validate_isbn()
-    rescue
-      _ -> :help
+    else
+      :help
     end
   end
 
-  def args_to_internal_representation(_), do: :help
-
-  # Check isbn length is 10 or 13
-  # returns isbn or :help if not valid
-  def validate_isbn(isbn) when not (length(isbn) == 10 or length(isbn) == 13), do: :help
-
-  def validate_isbn(isbn), do: Integer.undigits(isbn)
-
   def process(:help) do
     IO.puts("""
-    usage: isbn <isbn>
+    usage: isbn --isbn <isbn>
     """)
 
     System.halt(0)

--- a/test/isbn_test.exs
+++ b/test/isbn_test.exs
@@ -2,7 +2,11 @@ defmodule IsbnTest do
   use ExUnit.Case
   doctest Isbn
 
-  test "greets the world" do
-    assert Isbn.hello() == :world
+  test "check command line argument" do
+    assert ISBN.CLI.args_to_internal_representation(["--help"]) == :help
+    assert ISBN.CLI.args_to_internal_representation(["wrong args"]) == :help
+    assert ISBN.CLI.args_to_internal_representation(["1234567891234"]) == 1_234_567_891_234
+    assert ISBN.CLI.args_to_internal_representation(["1234567891"]) == 1_234_567_891
+    assert ISBN.CLI.args_to_internal_representation(["123"]) == :help
   end
 end

--- a/test/isbn_test.exs
+++ b/test/isbn_test.exs
@@ -3,10 +3,13 @@ defmodule IsbnTest do
   doctest Isbn
 
   test "check command line argument" do
-    assert ISBN.CLI.args_to_internal_representation(["--help"]) == :help
-    assert ISBN.CLI.args_to_internal_representation(["wrong args"]) == :help
-    assert ISBN.CLI.args_to_internal_representation(["1234567891234"]) == 1_234_567_891_234
-    assert ISBN.CLI.args_to_internal_representation(["1234567891"]) == 1_234_567_891
-    assert ISBN.CLI.args_to_internal_representation(["123"]) == :help
+    assert ISBN.CLI.parse_args(["--help"]) == :help
+    assert ISBN.CLI.parse_args([]) == :help
+
+    assert ISBN.CLI.parse_args(["--isbn", "1234567891234"]) ==
+             1_234_567_891_234
+
+    assert ISBN.CLI.parse_args(["-i", "1234567891"]) == 1_234_567_891
+    assert ISBN.CLI.parse_args(["--isbn", "123"]) == :help
   end
 end


### PR DESCRIPTION
ref: #1
parse command line arguments. Returns `:help` if isbn is not valid